### PR TITLE
Fix/show first row

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import {
   checkboxColumn,
   Column,
@@ -80,7 +80,18 @@ function App() {
     { title: 'Local de residência e trabalho', width: 1920 },
     { title: 'Dias trabalhados presencialmente', width: 1296 },
     { title: 'Dias trabalhados em home-office', width: 300 },
-  ];
+  ]
+
+  const [childrenHeight, setChildrenHeight] = useState(0)
+  const childrenRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (childrenRef.current) {
+      // Obtém a altura do elemento que contém os children
+      const height = childrenRef.current.clientHeight
+      setChildrenHeight(height)
+    }
+  }, [])
 
   return (
     <div
@@ -91,12 +102,14 @@ function App() {
         background: '#f3f3f3',
       }}
     >
-      <DataSheetGrid value={data} onChange={setData} columns={columns} >
-       </DataSheetGrid>
+      <DataSheetGrid
+        value={data}
+        onChange={setData}
+        columns={columns}
+      ></DataSheetGrid>
 
-       <DynamicDataSheetGrid value={data} onChange={setData} columns={columns}>
-        
-        <div className="overflow-x-hidden " >
+      <DynamicDataSheetGrid value={data} onChange={setData} columns={columns} childrenHeight={childrenHeight}>
+        <div className="overflow-x-hidden " ref={childrenRef}>
           <table className="w-full min-w-full">
             <thead>
               <tr>
@@ -106,8 +119,9 @@ function App() {
                     style={{
                       minWidth: `${item.width}px`,
                       width: `${item.width}px`,
+                      fontSize: '0.75rem',
                     }}
-                    className={`bg-gray-50 border-b border-l border-gray-200 px-4 py-2 font-semibold text-sm text-gray-600
+                    className={`bg-gray-50 border-b border-l border-gray-200 px-4 py-2 font-semibold text-lg text-gray-600
                 
                 `}
                   >
@@ -118,7 +132,7 @@ function App() {
             </thead>
           </table>
         </div>
-          </DynamicDataSheetGrid>
+      </DynamicDataSheetGrid>
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compensa-datasheet-grid",
-  "version": "4.22.0",
+  "version": "4.23.0",
   "description": "An Excel-like React component to create beautiful spreadsheets.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -66,6 +66,7 @@ export const DataSheetGrid = React.memo(
       {
         value: data = DEFAULT_DATA,
         children,
+        childrenHeight,
         className,
         style,
         height: maxHeight = 400,
@@ -1802,8 +1803,10 @@ export const DataSheetGrid = React.memo(
             cellClassName={cellClassName}
             onScroll={onScroll}
             fakeHeader={children}
+            childrenHeight={childrenHeight}
           >
             <SelectionRect
+              childrenHeight={childrenHeight}
               fakeHeader={children}
               columnRights={columnRights}
               columnWidths={columnWidths}

--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -1803,10 +1803,8 @@ export const DataSheetGrid = React.memo(
             onScroll={onScroll}
             fakeHeader={children}
           >
-
-          
-
             <SelectionRect
+              fakeHeader={children}
               columnRights={columnRights}
               columnWidths={columnWidths}
               activeCell={activeCell}
@@ -1824,7 +1822,6 @@ export const DataSheetGrid = React.memo(
               expandSelection={expandSelection}
 
             />
-            {/* {children} */}
           </Grid>
           <div
             ref={afterTabIndexRef}

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -37,6 +37,7 @@ export const Grid = <T extends any>({
   stopEditing,
   onScroll,
   fakeHeader,
+  childrenHeight
 }: {
   data: T[]
   columns: Column<T, any, any>[]
@@ -63,6 +64,7 @@ export const Grid = <T extends any>({
   stopEditing: (opts?: { nextRow?: boolean }) => void
   onScroll?: React.UIEventHandler<HTMLDivElement>
   fakeHeader?: ReactNode
+  childrenHeight?: number
 }) => {
   const rowVirtualizer = useVirtualizer({
     count: data.length,
@@ -225,7 +227,7 @@ export const Grid = <T extends any>({
               )}
               style={{
                 height: row.size,
-                top: fakeHeader === undefined ? row.start : row.start + 22,
+                top: fakeHeader === undefined ? row.start : row.start + (childrenHeight || 22),
                 width: fullWidth ? '100%' : colVirtualizer.getTotalSize(),
               }}
             >

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -225,7 +225,7 @@ export const Grid = <T extends any>({
               )}
               style={{
                 height: row.size,
-                top: fakeHeader === undefined ? row.start : row.start + 40,
+                top: fakeHeader === undefined ? row.start : row.start + 22,
                 width: fullWidth ? '100%' : colVirtualizer.getTotalSize(),
               }}
             >

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -133,7 +133,7 @@ export const Grid = <T extends any>({
       onScroll={onScroll}
       style={{ height: displayHeight }}
     >
-      
+
       <div
         ref={innerRef}
         style={{
@@ -225,7 +225,7 @@ export const Grid = <T extends any>({
               )}
               style={{
                 height: row.size,
-                top: row.start,
+                top: fakeHeader === undefined ? row.start : row.start + 40,
                 width: fullWidth ? '100%' : colVirtualizer.getTotalSize(),
               }}
             >

--- a/src/components/SelectionRect.tsx
+++ b/src/components/SelectionRect.tsx
@@ -41,6 +41,7 @@ const buildClipPath = (
 
 export const SelectionRect = React.memo<SelectionContextType>(
   ({
+    fakeHeader,
     columnWidths,
     columnRights,
     headerRowHeight,
@@ -86,12 +87,13 @@ export const SelectionRect = React.memo<SelectionContextType>(
     const extraPixelH = (colI: number): number => {
       return colI < columnWidths.length - (hasStickyRightColumn ? 3 : 2) ? 1 : 0
     }
-
+    const headerSizeFit = fakeHeader === undefined ? 0: 22 
+    
     const activeCellRect = activeCell && {
       width: columnWidths[activeCell.col + 1] + extraPixelH(activeCell.col),
       height: rowHeight(activeCell.row).height + extraPixelV(activeCell.row),
       left: columnRights[activeCell.col],
-      top: rowHeight(activeCell.row).top + headerRowHeight,
+      top: rowHeight(activeCell.row).top + headerRowHeight+headerSizeFit,
     }
 
     const selectionRect = selection && {
@@ -105,7 +107,7 @@ export const SelectionRect = React.memo<SelectionContextType>(
         rowHeight(selection.min.row).top +
         extraPixelV(selection.max.row),
       left: columnRights[selection.min.col],
-      top: rowHeight(selection.min.row).top + headerRowHeight,
+      top: rowHeight(selection.min.row).top + headerRowHeight+headerSizeFit,
     }
 
     const minSelection = selection?.min || activeCell

--- a/src/components/SelectionRect.tsx
+++ b/src/components/SelectionRect.tsx
@@ -42,6 +42,7 @@ const buildClipPath = (
 export const SelectionRect = React.memo<SelectionContextType>(
   ({
     fakeHeader,
+    childrenHeight,
     columnWidths,
     columnRights,
     headerRowHeight,
@@ -87,7 +88,7 @@ export const SelectionRect = React.memo<SelectionContextType>(
     const extraPixelH = (colI: number): number => {
       return colI < columnWidths.length - (hasStickyRightColumn ? 3 : 2) ? 1 : 0
     }
-    const headerSizeFit = fakeHeader === undefined ? 0: 22 
+    const headerSizeFit = fakeHeader === undefined ? 0: childrenHeight || 22 
     
     const activeCellRect = activeCell && {
       width: columnWidths[activeCell.col + 1] + extraPixelH(activeCell.col),

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export type Column<T, C, PasteValue> = {
 
 export type SelectionContextType = {
   fakeHeader?: ReactNode
+  childrenHeight?: number
   columnRights?: number[]
   columnWidths?: number[]
   activeCell: Cell | null
@@ -128,6 +129,7 @@ export type Operation = {
 export type DataSheetGridProps<T> = {
   value?: T[]
   children?: React.ReactNode
+  childrenHeight?: number
   style?: React.CSSProperties
   className?: string
   rowClassName?:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
 export type Cell = {
   col: number
@@ -57,6 +57,7 @@ export type Column<T, C, PasteValue> = {
 }
 
 export type SelectionContextType = {
+  fakeHeader?: ReactNode
   columnRights?: number[]
   columnWidths?: number[]
   activeCell: Cell | null


### PR DESCRIPTION
Correção fix: ao se inserir um linha adicional de header, a primeira celular de dados é sobreposta, por causa do ajuste da classe com top iniciando em 40 usado pela lib. Então é necessário somar a essa constante a altura da linha do header que dependerá da quantidade de conteúdo e do tamanho da fonte, por isso a necessidade de passar para o datasheet por props essa altura, quando ela for usada, com base no elemento. 
É importante então que ao se usar o componente datasheet com essa finalidade, pegue através da ref essa altura do elemento para passar para lib, caso não seja enviada será atribuído o valor 22 que corresponde a 1 linha de font-size:xs (mas poderá ser insuficiente)

PS: o ajuste foi feito para a posição da primeira linha, para a função selecionar células e para a função de célula ativa.